### PR TITLE
Add animals to shelter serializer

### DIFF
--- a/app/serializers/shelter_serializer.rb
+++ b/app/serializers/shelter_serializer.rb
@@ -1,7 +1,7 @@
 class ShelterSerializer
     include JSONAPI::Serializer
 
-    attributes :name, :user_id
+    attributes :name, :user_id, :animals
 
     has_many :animals, serializer: AnimalSerializer
 end


### PR DESCRIPTION
After much finagling, and trying to hand roll the shelter serializer, i figured out you can add :animals as an attribute and it will return all of the animals attributes that way, only slightly redundant as I could not for the life of me get it to return attributes in the relationships part, and handrolling caused a lot more problems than it was worth (trying to adjust to handle both one shelter object and an array of shelter object).